### PR TITLE
support older redis versions that may not have the requested stat keys

### DIFF
--- a/lib/redis-stat.rb
+++ b/lib/redis-stat.rb
@@ -202,7 +202,7 @@ private
       :aof_enabled,
       :vm_enabled
     ].each do |key|
-      tab << [ansi(:bold) { key }] + info[key]
+      tab << [ansi(:bold) { key }] + info[key] if info[key]
     end
     @os.puts tab
   end


### PR DESCRIPTION
Redis 2.2.5 does not support the :gcc_version stat key. This change handles unavailable stat keys.
