### PR TITLE
Horizontal scroll support for Instance information

### DIFF
--- a/lib/redis-stat/server/public/css/site.css
+++ b/lib/redis-stat/server/public/css/site.css
@@ -42,6 +42,10 @@ body {
   font-style: italic;
 }
 
+#info_table.table {
+  margin: 0;
+}
+
 .footer {
   padding: 30px 0;
   margin-top: 30px;
@@ -64,3 +68,12 @@ body {
   margin-right: 10px;
 }
 
+.scrollable {
+  background-color: #fff;
+  border: 1px solid #ddd;
+  -webkit-border-radius: 4px;
+     -moz-border-radius: 4px;
+          border-radius: 4px;
+  background-color: transparent;
+  overflow: auto;
+}

--- a/lib/redis-stat/server/views/index.erb
+++ b/lib/redis-stat/server/views/index.erb
@@ -74,11 +74,11 @@
       </div>
 
       <div class="row">
-        <div class="span<%= [12, 2 + @hosts.length * 2].min %>">
-          <table id="info_table" class="table table-striped table-bordered table-condensed table-hover">
+        <div class="span12 scrollable">
+          <table id="info_table" class="table table-striped table-condensed table-hover">
             <thead>
               <tr>
-                <td></td>
+                <td width="1"></td>
                 <% @hosts.each do |host| %>
                   <th class="text-info"><%= host %></th>
                 <% end %>


### PR DESCRIPTION
Hello & thank you for your great work!
We are very happy to use redis-stat for our production monitoring.

We have Redis clusters consist of many instances. With these clusters, An instance information table looks broken in the Web UI.

So I added horizontal scrolling for instance information area. If you like it, please merge.

Thanks.
