### PR TITLE
Left headers of instance info table are always fixed

### DIFF
--- a/lib/redis-stat/server/public/css/site.css
+++ b/lib/redis-stat/server/public/css/site.css
@@ -38,14 +38,6 @@ body {
   font-size: 11px;
 }
 
-#info_table th {
-  font-style: italic;
-}
-
-#info_table.table {
-  margin: 0;
-}
-
 .footer {
   padding: 30px 0;
   margin-top: 30px;
@@ -68,12 +60,36 @@ body {
   margin-right: 10px;
 }
 
-.scrollable {
+.info-wrapper {
   background-color: #fff;
   border: 1px solid #ddd;
   -webkit-border-radius: 4px;
      -moz-border-radius: 4px;
           border-radius: 4px;
   background-color: transparent;
+  padding: 0;
+}
+
+.info-wrapper div, .info-wrapper table.table {
+  margin: 0;
+}
+
+.info-wrapper th {
+  font-style: italic;
+}
+
+.info-wrapper .span2 {
+  width: 180px;
+}
+
+.info-wrapper .span2 table.table {
+  border-right: 1px solid #ddd;
+}
+
+.info-wrapper .span10 {
+  width: 760px;
+}
+
+.scrollable {
   overflow: auto;
 }

--- a/lib/redis-stat/server/public/js/site.js
+++ b/lib/redis-stat/server/public/js/site.js
@@ -150,7 +150,7 @@ var updateTable = function() {
   // Instance information (mostly static)
   for (var stat in js) {
     $("#" + stat).replaceWith(
-      "<tr id='" + stat + "'><th>" + stat + "</th>" +
+      "<tr id='" + stat + "'>" +
       js[stat].map(function(e) { return "<td>" + (e == null ? "" : e) + "</td>" }).join() +
       "</tr>"
     )

--- a/lib/redis-stat/server/views/index.erb
+++ b/lib/redis-stat/server/views/index.erb
@@ -74,31 +74,45 @@
       </div>
 
       <div class="row">
-        <div class="span12 scrollable">
-          <table id="info_table" class="table table-striped table-condensed table-hover">
-            <thead>
-              <tr>
-                <td width="1"></td>
-                <% @hosts.each do |host| %>
-                  <th class="text-info"><%= host %></th>
+        <div class="span12 info-wrapper">
+          <div class="span2">
+            <table class="table table-striped table-condensed">
+              <thead>
+                <tr>
+                  <th>&nbsp;</th>
+                </tr>
+              </thead>
+              <tbody>
+                <% @tab_measures.each do |stat| %>
+                <tr>
+                  <th><%= stat %></th>
+                </tr>
                 <% end %>
-              </tr>
-            </thead>
-            <tbody>
-              <% @tab_measures.each do |stat| %>
-              <tr id="<%= stat %>">
-                <th>
-                  <%= stat %>
-                </th>
-                <% @hosts.each_with_index do |host, idx| %>
-                <td>
-                  <%= @info[stat][idx] %>
-                </td>
+              </tbody>
+            </table>
+          </div>
+          <div class="span10 scrollable">
+            <table class="table table-striped table-condensed">
+              <thead>
+                <tr>
+                  <% @hosts.each do |host| %>
+                    <th class="text-info"><%= host %></th>
+                  <% end %>
+                </tr>
+              </thead>
+              <tbody>
+                <% @tab_measures.each do |stat| %>
+                <tr id="<%= stat %>">
+                  <% @hosts.each_with_index do |host, idx| %>
+                  <td>
+                    <%= @info[stat][idx] %>
+                  </td>
+                  <% end %>
+                </tr>
                 <% end %>
-              </tr>
-              <% end %>
-            </tbody>
-          </table>
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
As I said yesterday, I've modified an instance information table to lock the left headers.
Please review, then merge this if you like.

Thanks.

p.s. I've tried CSS hack-ways but it was so tricky. So I use 2 tables instead.
