### PR TITLE
use json 1.8.2 gem

### DIFF
--- a/redis-stat.gemspec
+++ b/redis-stat.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "parallelize", '~> 0.4.0'
   gem.add_runtime_dependency "si", '~> 0.1.4'
   gem.add_runtime_dependency "sinatra", '~> 1.3.3'
-  gem.add_runtime_dependency "json", '~> 1.7.5'
+  gem.add_runtime_dependency "json", '~> 1.8.2'
   gem.add_runtime_dependency "lps", '~> 0.2.0'
   gem.add_runtime_dependency "elasticsearch", '~> 1.0.0'
 


### PR DESCRIPTION
I can't install redis-stat with ruby 2.2.0, as its dependency json 1.7.7 is not compatible with ruby 2.2.0, but I successfully install json 1.8.2, I think upgrading dependency json 1.7.7 to 1.8.2 can solve the problem.

https://github.com/flori/json/issues/229