### PR TITLE
Some refactoring

### DIFF
--- a/lib/redis-stat.rb
+++ b/lib/redis-stat.rb
@@ -28,13 +28,14 @@ class RedisStat
 
     @hosts         = options[:hosts]
     @interval      = options[:interval]
-    @redises       = @hosts.inject({}) { |hash, e|
+    @redises       = @hosts.each_with_object({}) do |e, hash|
       host, port   = e.split(':')
-      hash[e] = Redis.new(Hash[ {:host => host,
-                                 :port => port,
-                                 :timeout => @interval}.select { |k, v| v } ])
-      hash
-    }
+      hash[e] = Redis.new({
+        :host => host,
+        :port => port,
+        :timeout => @interval
+      })
+    end
     @max_count     = options[:count]
     @colors        = options[:colors] || COLORS
     @csv_file      = options[:csv_file]

--- a/test/test_redis-stat.rb
+++ b/test/test_redis-stat.rb
@@ -163,7 +163,7 @@ class TestRedisStat < MiniTest::Unit::TestCase
       %w[localhost 5 0]
     ].each do |argv|
       assert_raises(SystemExit) {
-        options = RedisStat::Option.parse(argv)
+        RedisStat::Option.parse(argv)
       }
     end
 
@@ -230,4 +230,3 @@ class TestRedisStat < MiniTest::Unit::TestCase
     end
   end
 end
-


### PR DESCRIPTION
inject -> each_with_object
Hash[] is not nedeed here since we already have a hash.
The select seems to be there to remove empty values, in my opinion this is best handled by setting defaults. It seems like this is already being handled somewhere else or it's not being covered by test.