### PR TITLE
Es tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ usage: redis-stat [HOST[:PORT] ...] [INTERVAL [COUNT]]
         --no-color                   Suppress ANSI color codes
         --csv=OUTPUT_CSV_FILE_PATH   Save the result in CSV format
         --es=ELASTICSEARCH_URL       Send results to ElasticSearch: [http://]HOST[:PORT][/INDEX]
+        --estags=ELASTICSEARCH_TAGS  List of comma seperated tags to add ro results sent to ElasticSearch: tag1,tag2
 
         --server[=PORT]              Launch redis-stat web server (default port: 63790)
         --daemon                     Daemonize redis-stat. Must be used with --server option.
@@ -91,6 +92,7 @@ printed as they are not supported in the default Windows command prompt.
 - [Chris Meisl](https://github.com/cmeisl)
 - [Hyunseok Hwang](https://github.com/frhwang)
 - [Sent Hil](https://github.com/sent-hil)
+- [Salvatore Poliandro](https://github.com/popsikle)
 
 ## Contributing
 

--- a/lib/redis-stat.rb
+++ b/lib/redis-stat.rb
@@ -51,7 +51,7 @@ class RedisStat
     @server_port   = options[:server_port]
     @server_thr    = nil
     @daemonized    = options[:daemon]
-    @elasticsearch = options[:es] && ElasticsearchSink.new(@hosts, options[:es])
+    @elasticsearch = options[:es] && ElasticsearchSink.new(@hosts, options[:es], options[:tags])
   end
 
   def output_stream! stream

--- a/lib/redis-stat/elasticsearch.rb
+++ b/lib/redis-stat/elasticsearch.rb
@@ -24,7 +24,7 @@ class ElasticsearchSink
   def initialize hosts, elasticsearch, tags = nil
     url, @index  = elasticsearch
     @hosts       = hosts
-    @tags = tags || []
+    @tags        = tags || []
     @client      = Elasticsearch::Client.new :url => url
   end
 

--- a/lib/redis-stat/elasticsearch.rb
+++ b/lib/redis-stat/elasticsearch.rb
@@ -21,9 +21,10 @@ class ElasticsearchSink
     [uri.to_s, index]
   end
 
-  def initialize hosts, elasticsearch
+  def initialize hosts, elasticsearch, tags = nil
     url, @index  = elasticsearch
     @hosts       = hosts
+    @tags = tags || []
     @client      = Elasticsearch::Client.new :url => url
   end
 
@@ -43,7 +44,8 @@ class ElasticsearchSink
         :body  => entries.merge({
           :@timestamp => format_time(time),
           :host       => host,
-          :at         => time.to_f
+          :at         => time.to_f,
+          :tags       => @tags
         }),
       }
 

--- a/lib/redis-stat/option.rb
+++ b/lib/redis-stat/option.rb
@@ -8,7 +8,7 @@ module Option
     :count      => nil,
     :csv_file   => nil,
     :csv_output => false,
-    :style      => :unicode
+    :style      => :unicode,
   }
 
   def self.parse argv
@@ -45,6 +45,11 @@ module Option
 
       opts.on('--es=ELASTICSEARCH_URL', 'Send results to ElasticSearch: [http://]HOST[:PORT][/INDEX]') do |v|
         options[:es] = RedisStat::ElasticsearchSink.parse_url v
+        options[:tags] = [] unless options[:tags]
+      end
+
+      opts.on('--estags=ELASTICSEARCH_TAGS', 'List of comma seperated tags to add ro results sent to ElasticSearch: tag1,tag2') do |v|
+        options[:tags] = v.split(',')
       end
 
       opts.separator ''

--- a/test/test_redis-stat.rb
+++ b/test/test_redis-stat.rb
@@ -118,7 +118,8 @@ class TestRedisStat < MiniTest::Unit::TestCase
       :csv_file => '/tmp/a.csv',
       :csv_output => false,
       :style => :ascii,
-      :es => %w[http://localhost index]
+      :es => %w[http://localhost index],
+      :tags => []
     }.sort, options.sort)
 
     options = RedisStat::Option.parse(%w[-h localhost:8888 10 -a password --csv --style=ascii --es=localhost/index])
@@ -130,7 +131,21 @@ class TestRedisStat < MiniTest::Unit::TestCase
       :csv_file => nil,
       :csv_output => true,
       :style => :ascii,
-      :es => %w[http://localhost index]
+      :es => %w[http://localhost index],
+      :tags => []
+    }.sort, options.sort)
+
+    options = RedisStat::Option.parse(%w[-h localhost:8888 10 -a password --csv --style=ascii --es=localhost/index --estags=tag1,tag4])
+    assert_equal({
+      :auth => 'password',
+      :hosts => ['localhost:8888'],
+      :interval => 10,
+      :count => nil,
+      :csv_file => nil,
+      :csv_output => true,
+      :style => :ascii,
+      :es => %w[http://localhost index],
+      :tags => ['tag1','tag4']
     }.sort, options.sort)
 
     # Server


### PR DESCRIPTION
I am running a dozen instances of this pointing at the same ES cluster, and I needed a way to separate the events. tags for elasticsearch entries is the standard way of doing something like that, so I added tags =)
